### PR TITLE
fix(import-world): #MX-134 add check before import + update info world

### DIFF
--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -1,5 +1,6 @@
 {
   "minetest.allow.access.world.password": "Permettre l'accès du monde via un mot de passe",
+  "minetest.added": "Ajouté",
   "minetest.cancel": "Annuler",
   "minetest.copy.url.address": "Copier l'adresse",
   "minetest.add.image": "Ajouter une image",

--- a/src/main/resources/public/ts/controllers/minetest.controller.ts
+++ b/src/main/resources/public/ts/controllers/minetest.controller.ts
@@ -77,9 +77,14 @@ class Controller implements ng.IController, IViewModel {
     setStatus(world: IWorld): string {
         let open: string = lang.translate('minetest.open');
         let close: string = lang.translate('minetest.close');
-        if(world.status) {
-            return open;
-        } else return close;
+        let added: string = lang.translate('minetest.added');
+
+        if (world.password) {
+            if (world.status) {
+                return open;
+            } else return close;
+        }
+        else return added;
     }
 
     getLink(): string {

--- a/src/main/resources/public/ts/directives/import-world/import-world.html
+++ b/src/main/resources/public/ts/directives/import-world/import-world.html
@@ -45,6 +45,9 @@
         </div>
 
         <!-- button import world -->
-        <button class="custom-button right-magnet" ng-click="vm.importWorld()"><i18n>minetest.import</i18n></button>
+        <button class="custom-button right-magnet"
+                data-ng-disabled="!vm.world.title || !vm.world.address || !vm.world.port" ng-click="vm.importWorld()">
+            <i18n>minetest.import</i18n>
+        </button>
     </lightbox>
 </div>

--- a/src/main/resources/public/ts/models/minetest.model.ts
+++ b/src/main/resources/public/ts/models/minetest.model.ts
@@ -6,14 +6,13 @@ export interface IWorld {
 
     created_at: string;
     updated_at: string;
+
     password: string;
     status?: boolean;
-
     img?: string;
     title: string;
 
     address: string;
-
     port?: number;
 }
 


### PR DESCRIPTION
## Describe your changes
Add check on import button : you can't import if one of the input is empty
Change info world "open / close the" for import world by "added the"

## Checklist tests
Try to import world with title, address or port empty

## Issue ticket number and link
https://entsupport.gdapublic.fr/browse/MEX-134

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

