### PR TITLE
fix(properties-world): #MX-150 add check if input are not empty

### DIFF
--- a/src/main/resources/i18n/en.json
+++ b/src/main/resources/i18n/en.json
@@ -31,7 +31,7 @@
   "minetest.port": "Port",
   "minetest.properties": "Properties",
   "minetest.reset.password": "Reset password",
-  "minetest.reset.password.explanation": "You can re-mail the world to let users know the new password",
+  "minetest.reset.password.explanation": "You could re-mail the world to let users know the new password",
   "minetest.share": "Share",
   "minetest.the": "the",
   "minetest.title": "Minetest",

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -32,7 +32,7 @@
   "minetest.port": "Port",
   "minetest.properties": "Propriétés",
   "minetest.reset.password": "Réinitialiser le mot de passe",
-  "minetest.reset.password.explanation": "Vous pouvez publiposter de nouveau le monde pour faire part du nouveau mot de passe aux utilisateurs",
+  "minetest.reset.password.explanation": "Vous pourrez publiposter de nouveau le monde pour faire part du nouveau mot de passe aux utilisateurs",
   "minetest.share": "Partager",
   "minetest.the": "le",
   "minetest.title": "Minetest",

--- a/src/main/resources/public/sass/global/components/containers/properties-world/_properties-world.scss
+++ b/src/main/resources/public/sass/global/components/containers/properties-world/_properties-world.scss
@@ -24,6 +24,12 @@
     font-size: 14px;
   }
 
+  .custom-button[disabled=disabled] {
+    color: #b1b6bf;
+    background: #8c939e;
+    cursor: default;
+  }
+
   .medium-text {
     button[disabled=disabled] {
       color: $minetest-orange;

--- a/src/main/resources/public/ts/directives/properties-world/properties-world.html
+++ b/src/main/resources/public/ts/directives/properties-world/properties-world.html
@@ -82,10 +82,13 @@
         </div>
 
         <!-- button action update -->
-        <button ng-show="!vm.world.isExternal" class="custom-button right-magnet" ng-click="vm.updateWorld()">
+        <button ng-show="!vm.world.isExternal" class="custom-button right-magnet" ng-click="vm.updateWorld()"
+                data-ng-disabled="vm.worldForm.title.length < 1 || (vm.showInputPassword && vm.worldForm.password.length < 1)">
             <i18n>minetest.world.update</i18n>
         </button>
-        <button ng-show="vm.world.isExternal" class="custom-button right-magnet" ng-click="vm.updateImportWorld()">
+        <button ng-show="vm.world.isExternal" class="custom-button right-magnet" ng-click="vm.updateImportWorld()"
+                data-ng-disabled="vm.worldForm.title.length < 1 || vm.worldForm.address.length < 1
+                || vm.worldForm.port.length < 1">
             <i18n>minetest.world.update</i18n>
         </button>
     </lightbox>


### PR DESCRIPTION
## Describe your changes
Add check when update : if input title or password are empty, btn update is disable

## Checklist tests
Try to update when title or password empty

## Issue ticket number and link
[MEX-150] https://entsupport.gdapublic.fr/browse/MEX-150

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

