### PR TITLE
MEX -156

### DIFF
--- a/src/main/java/fr/openent/minetest/controller/MinetestController.java
+++ b/src/main/java/fr/openent/minetest/controller/MinetestController.java
@@ -69,7 +69,7 @@ public class MinetestController extends ControllerHelper {
     public void postWorld(final HttpServerRequest request) {
         RequestUtils.bodyToJson(request, pathPrefix + Field.WORLD, body
                 -> UserUtils.getUserInfos(eb, request, user
-                -> worldService.create(body,user)
+                -> worldService.create(body, user)
                 .onSuccess(res -> renderJson(request, body))
                 .onFailure(err -> renderError(request))));
     }

--- a/src/main/java/fr/openent/minetest/service/impl/DefaultWorldService.java
+++ b/src/main/java/fr/openent/minetest/service/impl/DefaultWorldService.java
@@ -128,6 +128,9 @@ public class DefaultWorldService implements WorldService {
 
         String loginMinetest = reformatLogin(user.getLogin());
 
+        //Put new Id
+        body.put(Field._ID, UUID.randomUUID().toString());
+
         //add user in the whitelist
         createWhitelist(body, user, loginMinetest);
 

--- a/src/main/resources/public/template/main.html
+++ b/src/main/resources/public/template/main.html
@@ -20,10 +20,10 @@
             </span>
         </div>
         <div class="minetest-head" data-ng-show="vm.worlds.all.length > 0">
-            <!-- button import first world -->
-            <import-world on-import-world="vm.refreshWorldList"></import-world>
-            <!-- button create first world -->
-            <create-world on-create-world="vm.refreshWorldList"></create-world>
+            <!-- button import world -->
+            <import-world on-import-world="vm.refreshWorldList()"></import-world>
+            <!-- button create world -->
+            <create-world on-create-world="vm.refreshWorldList()"></create-world>
         </div>
     </div>
 
@@ -38,10 +38,10 @@
             <i18n>minetest.world.empty.state</i18n>
         </div>
         <div class="empty-state-button">
-            <!-- button import world -->
-            <import-world on-import-world="vm.refreshWorldList"></import-world>
-            <!-- button create world -->
-            <create-world on-create-world="vm.refreshWorldList"></create-world>
+            <!-- button import first world -->
+            <import-world on-import-world="vm.refreshWorldList()"></import-world>
+            <!-- button create first world -->
+            <create-world on-create-world="vm.refreshWorldList()"></create-world>
         </div>
     </div>
 

--- a/src/main/resources/public/template/main.html
+++ b/src/main/resources/public/template/main.html
@@ -21,9 +21,9 @@
         </div>
         <div class="minetest-head" data-ng-show="vm.worlds.all.length > 0">
             <!-- button import first world -->
-            <import-world on-import-world="vm.refreshWorldList()"></import-world>
+            <import-world on-import-world="vm.refreshWorldList"></import-world>
             <!-- button create first world -->
-            <create-world on-create-world="vm.refreshWorldList()"></create-world>
+            <create-world on-create-world="vm.refreshWorldList"></create-world>
         </div>
     </div>
 
@@ -39,9 +39,9 @@
         </div>
         <div class="empty-state-button">
             <!-- button import world -->
-            <import-world on-import-world="vm.refreshWorldList()"></import-world>
+            <import-world on-import-world="vm.refreshWorldList"></import-world>
             <!-- button create world -->
-            <create-world on-create-world="vm.refreshWorldList()"></create-world>
+            <create-world on-create-world="vm.refreshWorldList"></create-world>
         </div>
     </div>
 

--- a/src/main/resources/public/ts/controllers/minetest.controller.ts
+++ b/src/main/resources/public/ts/controllers/minetest.controller.ts
@@ -9,12 +9,12 @@ declare let window: any;
 interface IViewModel {
     initData(): Promise<void>;
     getWorld(): Promise<void>;
-    setCurrentWorld(): void;
+    setCurrentWorld(world?: IWorld): void;
     setStatus(world: IWorld): string;
     getLink(): string;
     getWiki(): string;
     getDownload(): string;
-    refreshWorldList(world?): any;
+    refreshWorldList(world?: IWorld): any;
 
     world: IWorld;
 }
@@ -60,15 +60,15 @@ class Controller implements ng.IController, IViewModel {
         safeApply(this.$scope);
     }
 
-    async getWorld(world?): Promise<void> {
+    async getWorld(world?: IWorld): Promise<void> {
         this.worlds.all = await minetestService.get(this.user_id, this.user_name);
         if (world) {
-            let currentWorld = this.worlds.all.find(w => w._id === world._id)
+            let currentWorld: IWorld = this.worlds.all.find(w => w._id === world._id)
             currentWorld ? this.setCurrentWorld(currentWorld) : this.setCurrentWorld();
         } else this.setCurrentWorld();
     }
 
-    setCurrentWorld(world?): void {
+    setCurrentWorld(world?: IWorld): void {
         this.currentWorld = world || this.currentWorld;
         if (this.currentWorld) this.currentWorld = this.worlds.all.find(w => w._id === this.currentWorld._id);
         this.currentWorld = this.currentWorld || this.worlds.all[0];
@@ -100,7 +100,7 @@ class Controller implements ng.IController, IViewModel {
         return window.minetestDownload;
     }
 
-    refreshWorldList(): (world) => any {
+    refreshWorldList(): (world?: IWorld) => any {
         let self: Controller = this;
         return (world: any): void => {
             self.getWorld(world);

--- a/src/main/resources/public/ts/controllers/minetest.controller.ts
+++ b/src/main/resources/public/ts/controllers/minetest.controller.ts
@@ -14,7 +14,7 @@ interface IViewModel {
     getLink(): string;
     getWiki(): string;
     getDownload(): string;
-    refreshWorldList(): Promise<void>;
+    refreshWorldList(world?): any;
 
     world: IWorld;
 }
@@ -60,18 +60,19 @@ class Controller implements ng.IController, IViewModel {
         safeApply(this.$scope);
     }
 
-    async getWorld(): Promise<void> {
+    async getWorld(world?): Promise<void> {
         this.worlds.all = await minetestService.get(this.user_id, this.user_name);
-        this.setCurrentWorld();
+        if (world) {
+            let currentWorld = this.worlds.all.find(w => w._id === world._id)
+            currentWorld ? this.setCurrentWorld(currentWorld) : this.setCurrentWorld();
+        } else this.setCurrentWorld();
     }
 
-    setCurrentWorld(): void {
-        if (this.currentWorld) {
-            let worldId = this.currentWorld._id
-            this.currentWorld = this.worlds.all.filter(w => w._id === worldId)[0]
-        } else {
-            this.currentWorld = this.worlds.all[0]
-        }
+    setCurrentWorld(world?): void {
+        this.currentWorld = world || this.currentWorld;
+        if (this.currentWorld) this.currentWorld = this.worlds.all.find(w => w._id === this.currentWorld._id);
+        this.currentWorld = this.currentWorld || this.worlds.all[0];
+        safeApply(this.$scope);
     }
 
     setStatus(world: IWorld): string {
@@ -99,9 +100,11 @@ class Controller implements ng.IController, IViewModel {
         return window.minetestDownload;
     }
 
-    async refreshWorldList(): Promise<void> {
-        await this.getWorld();
-        safeApply(this.$scope);
+    refreshWorldList(): (world) => any {
+        let self: Controller = this;
+        return (world: any): void => {
+            self.getWorld(world);
+        }
     }
 }
 

--- a/src/main/resources/public/ts/controllers/minetest.controller.ts
+++ b/src/main/resources/public/ts/controllers/minetest.controller.ts
@@ -23,7 +23,6 @@ class Controller implements ng.IController, IViewModel {
     currentWorld: IWorld;
     display: { allowPassword: boolean };
     filter: { creation_date: Date; up_date: Date; guests: any; shared: boolean; title: string };
-    selectedWorld: Array<IWorld>;
     user_id: string;
     user_name: string;
     user_login: string;
@@ -38,7 +37,6 @@ class Controller implements ng.IController, IViewModel {
         this.user_id = model.me.userId;
         this.user_name = model.me.username;
         this.user_login = model.me.login;
-        this.selectedWorld = [];
 
         this.filter = {
             creation_date: null,
@@ -49,7 +47,6 @@ class Controller implements ng.IController, IViewModel {
         };
 
         this.display = { allowPassword: false };
-
         this.worlds = new Worlds();
         this.worlds.all = [];
         this.initData();

--- a/src/main/resources/public/ts/directives/create-world/create-world.directive.ts
+++ b/src/main/resources/public/ts/directives/create-world/create-world.directive.ts
@@ -4,6 +4,7 @@ import {IScope} from "angular";
 import {IWorld} from "../../models";
 import {DateUtils} from "../../utils/date.utils";
 import {minetestService} from "../../services";
+import {AxiosResponse} from "axios";
 
 declare let window: any;
 
@@ -82,14 +83,17 @@ class Controller implements ng.IController, IViewModel {
             address: this.formatAddress()
         }
         minetestService.create(this.newWorld)
-            .then(() => {
+            .then((world: AxiosResponse) => {
                 toasts.confirm('minetest.world.create.confirm');
+                if (this.$scope.$parent.$eval(this.$scope['vm']['onCreateWorld'])(world.data))
+                    this.$scope.$parent.$eval(this.$scope['vm']['onCreateWorld'])(world.data);
                 this.closeCreateLightbox();
-                this.$scope.$eval(this.$scope['vm']['onCreateWorld']());
-            }).catch(() => {
-            toasts.warning('minetest.world.create.error');
-            this.closeCreateLightbox();
-        })
+            })
+            .catch(e => {
+                toasts.warning('minetest.world.create.error');
+                console.error(e);
+                this.closeCreateLightbox();
+            })
     }
 }
 
@@ -107,7 +111,6 @@ function directive() {
                         element: ng.IAugmentedJQuery,
                         attrs: ng.IAttributes,
                         vm: ng.IController) {
-
         }
     }
 }

--- a/src/main/resources/public/ts/directives/create-world/create-world.directive.ts
+++ b/src/main/resources/public/ts/directives/create-world/create-world.directive.ts
@@ -16,11 +16,13 @@ interface IViewModel {
 
     lightbox: any;
     world: IWorld;
+    newWorld: IWorld;
 }
 
 class Controller implements ng.IController, IViewModel {
     lightbox: any;
     world: IWorld;
+    newWorld: IWorld;
 
     constructor(private $scope: IScope)
     {
@@ -37,6 +39,8 @@ class Controller implements ng.IController, IViewModel {
 
     openCreateLightbox(): void {
         this.lightbox.create = true;
+        let newWorld: IWorld = this.world;
+        this.world = Object.assign({}, newWorld);
     }
 
     closeCreateLightbox(): void {
@@ -65,7 +69,7 @@ class Controller implements ng.IController, IViewModel {
     }
 
     async createWorld(): Promise<void> {
-        this.world = {
+        this.newWorld = {
             owner_id:  model.me.userId,
             owner_name: model.me.username,
             owner_login: model.me.login,
@@ -77,7 +81,7 @@ class Controller implements ng.IController, IViewModel {
             title: this.world.title,
             address: this.formatAddress()
         }
-        minetestService.create(this.world)
+        minetestService.create(this.newWorld)
             .then(() => {
                 toasts.confirm('minetest.world.create.confirm');
                 this.closeCreateLightbox();

--- a/src/main/resources/public/ts/directives/delete-world/delete-world.directive.ts
+++ b/src/main/resources/public/ts/directives/delete-world/delete-world.directive.ts
@@ -46,10 +46,12 @@ class Controller implements ng.IController, IViewModel {
                 toasts.confirm('minetest.world.delete.confirm');
                 this.closeDeleteLightbox();
                 this.$scope.$eval(this.$scope['vm']['onDeleteWorld']());
-            }).catch(() => {
-            toasts.warning('minetest.world.delete.error');
-            this.closeDeleteLightbox();
-        })
+            })
+            .catch(e => {
+                toasts.warning('minetest.world.delete.error');
+                console.error(e);
+                this.closeDeleteLightbox();
+            })
     }
 
     async deleteImportWorld(): Promise<void> {
@@ -57,7 +59,8 @@ class Controller implements ng.IController, IViewModel {
             .then(() => {
                 toasts.confirm('minetest.world.delete.confirm');
                 this.closeDeleteLightbox();
-                this.$scope.$eval(this.$scope['vm']['onDeleteWorld']());
+                if (this.$scope.$parent.$eval(this.$scope['vm']['onDeleteWorld'])(this.world))
+                    this.$scope.$parent.$eval(this.$scope['vm']['onDeleteWorld'])(this.world);
             }).catch(() => {
             toasts.warning('minetest.world.delete.error');
             this.closeDeleteLightbox();

--- a/src/test/java/fr/openent/minetest/services/DefaultWorldServiceTest.java
+++ b/src/test/java/fr/openent/minetest/services/DefaultWorldServiceTest.java
@@ -70,7 +70,7 @@ public class DefaultWorldServiceTest {
         try {
             Whitebox.invokeMethod(worldService, "importWorld", world, userInfos);
         } catch (Exception e) {
-            context.assertNull(e);
+            context.assertNotNull(e);
         }
     }
 

--- a/src/test/java/fr/openent/minetest/services/DefaultWorldServiceTest.java
+++ b/src/test/java/fr/openent/minetest/services/DefaultWorldServiceTest.java
@@ -38,12 +38,12 @@ public class DefaultWorldServiceTest {
     }
 
     @Test
-    public void testCreateImportWorld(TestContext context) {
+    public void testCreateImportWorld(TestContext context) throws Exception {
         // Arguments
         UserInfos userInfos = new UserInfos();
+        userInfos.setLogin("login");
 
         JsonObject world = new JsonObject()
-                .put("_id", "5fzef5")
                 .put("owner_id", "ownerId")
                 .put("owner_name", "ownerName")
                 .put("owner_login", "ownerLogin")
@@ -56,22 +56,21 @@ public class DefaultWorldServiceTest {
 
         //Expected data
         String expectedCollection = "world";
-        String expectedWorld = "{\"_id\":\"5fzef5\",\"owner_id\":\"ownerId\",\"owner_name\":\"ownerName\"," +
-                "\"owner_login\":\"ownerLogin\",\"created_at\":\"createdAt\",\"updated_at\":\"updatedAt\"," +
-                "\"title\":\"my world\",\"address\":\"myworld.fr\",\"port\":\"30000\",\"isExternal\":true}";
+        String expectedWorld = "{\"owner_id\":\"ownerId\",\"owner_name\":\"ownerName\",\"owner_login\":\"ownerLogin\"," +
+                "\"created_at\":\"createdAt\",\"updated_at\":\"updatedAt\",\"title\":\"my world\"," +
+                "\"address\":\"myworld.fr\",\"port\":\"30000\",\"isExternal\":true,\"whitelist\":[{\"id\":null," +
+                "\"login\":\"login\",\"displayName\":null,\"firstName\":null,\"lastName\":null,\"whitelist\":false}]}";
+
         Mockito.doAnswer(invocation -> {
             String collection = invocation.getArgument(0);
-            String query = invocation.getArgument(1).toString();
+            JsonObject query = invocation.getArgument(1);
+            query.remove("_id");
             context.assertEquals(collection, expectedCollection);
-            context.assertEquals(query, expectedWorld);
+            context.assertEquals(query.toString(), expectedWorld);
             return null;
         }).when(mongo).insert(Mockito.anyString(), Mockito.any(JsonObject.class), Mockito.any(Handler.class));
 
-        try {
-            Whitebox.invokeMethod(worldService, "importWorld", world, userInfos);
-        } catch (Exception e) {
-            context.assertNotNull(e);
-        }
+        Whitebox.invokeMethod(worldService, "importWorld", world, userInfos);
     }
 
 }


### PR DESCRIPTION
## Describe your changes
When create or import a new world, I should be selected as currentWorld.
When you delete a world, the first world of the list should be selected as currentWorld.

## Checklist tests
You can create new world : check if it's the one selected and display.
Same test when import world.
Delete a world, check if selected world is the first of the list.

## Issue ticket number and link
[MEX-154] https://entsupport.gdapublic.fr/browse/MEX-154
[MEX-156] https://entsupport.gdapublic.fr/browse/MEX-156

These two bug tickets actually have the same resolution, so I handled them in the same ticket.

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

