### PR TITLE
fix(properties-world): #MEX-253 update this.world when this.worldForm is updated

### DIFF
--- a/src/main/resources/public/ts/directives/properties-world/properties-world.directive.ts
+++ b/src/main/resources/public/ts/directives/properties-world/properties-world.directive.ts
@@ -61,6 +61,7 @@ class Controller implements ng.IController, IViewModel {
                 toasts.confirm('minetest.world.update.confirm');
                 this.closePropertiesLightbox();
                 this.$scope.$parent.$eval(this.$scope['vm']['onUpdateWorld'](this.worldForm));
+                this.world = {...this.worldForm};
             }).catch(() => {
             toasts.warning('minetest.world.update.error');
             this.closePropertiesLightbox();


### PR DESCRIPTION
## Describe your changes
Before this when updating the world name, the lightbox still displayed the old name.
It was due to two different variables to store the world properties : "world" and "worldForm".
This prevents to update the world with wrong values.
Now when the updated process is successful, a copy of "worldForm" is created and stored in "world" variable :
```
this.world = {...this.worldForm};
```

## Checklist tests
Create a world, then try to update the world's name by clicking on "Proprités" and make the change in the lightbox.

## Issue ticket number and link
https://jira.support-ent.fr/browse/MEX-253

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

