### PR TITLE
fix(css): #MEX-254 change cancel share button in grey default color

### DIFF
--- a/.github/workflows/dev-check-repository.yml
+++ b/.github/workflows/dev-check-repository.yml
@@ -7,17 +7,19 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: opendigitaleducation/node:10-alpine
+      image: opendigitaleducation/node:16-alpine
       options: --user root -v ${{ github.workspace }}:/home/node/:rw
 
     steps:
       - uses: actions/checkout@v1
-      - name: Run npm install
-        run: npm install
+      - name: Run yarn install
+        run: yarn install
       - name: Run build node with Gulp
         run: node_modules/gulp/bin/gulp.js build
       - name: Run test
-        run: npm test
+        run: yarn
+      - name: Run build-node-sass
+        run: yarn run build:sass
 
   build-gradle-test:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ module-starting-pack/src/main/resources/public/font
 /src/main/resources/public/js/
 /src/main/resources/view/
 /src/main/resources/public/font
+/src/main/resources/public/css/*
+yarn.lock

--- a/src/main/resources/public/sass/global/_minetest.scss
+++ b/src/main/resources/public/sass/global/_minetest.scss
@@ -9,7 +9,7 @@
   font-style: normal;
 }
 
-body.minetest {
+body.minetest-module {
   @import "components/index";
 }
 

--- a/src/main/resources/public/sass/global/components/containers/share-world/_share-world.scss
+++ b/src/main/resources/public/sass/global/components/containers/share-world/_share-world.scss
@@ -5,6 +5,20 @@
       color: $minetest-white;
       font-size: 14px;
       margin: 0 2px 10px;
+      padding: 8px 18px 10px;
+    }
+
+    button.cancel {
+      background: $minetest-grey;
+      color: $minetest-orange;
+    }
+
+    button.cancel:hover {
+      background-color: $minetest-orange;
+      box-shadow: none;
+      color: $minetest-white;
+      font-size: 14px;
+      margin: 0 2px 10px;
     }
 
     button:hover {

--- a/src/main/resources/view-src/minetest.html
+++ b/src/main/resources/view-src/minetest.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html lang="">
+<html with-theme-legacy>
 
 	<head>
 		<title>{{#i18n}}minetest.title{{/i18n}}</title>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 		<script src="/assets/js/entcore/ng-app.js?v=@@VERSION" type="text/javascript" id="context"></script>
 		<script src="/minetest/public/dist/application.js?v=@@VERSION" type="text/javascript"></script>
-		
+		<link rel="stylesheet" href="minetest/public/css/minetest.css?v=@@VERSION">
 		<script type="text/ng-template" id="empty"></script>
 
 		<script>
@@ -18,7 +18,7 @@
 		</script>
 	</head>
 
-	<body ng-controller="MainController as vm" class="minetest">
+	<body ng-controller="MainController as vm" class="minetest-module">
 		<portal>
 			<container template="main"></container>
 		</portal>


### PR DESCRIPTION
## Describe your changes
When we cancel sharing a world to someone, the color of  the cancel button of the lightbox is not the right one.
Adding some css made the magic happens

## Checklist tests
Share a world to someone by clicking on the world card then on "partager". Type a user name, add him and then try to close the lightbox, an other lightbox should open and check whether the cancel button is grey.

## Issue ticket number and link
https://jira.support-ent.fr/browse/MEX-254

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

